### PR TITLE
Add iTunes album cover downloader and finalize song #365

### DIFF
--- a/src/data/entries.json
+++ b/src/data/entries.json
@@ -9532,7 +9532,7 @@
     "number": 364,
     "song": "Your Still Standin' There",
     "artist": "Steve Earle",
-    "album": "I Feel Alright", 
+    "album": "I Feel Alright",
     "spotifyLink": "https://open.spotify.com/track/4sD5C8vtuPtblOYanu3jSc?si=49962da6290e4b16",
     "textBody": "5-8-2025: Your Still Standin' There\n\n\nFollowing up on the song I shared yesterday, passed to me by a friend of a friend. Turns out, it's a \"matt radosevich song\" in more ways than I realized:\n\nListen close to the backing vocals. One of them is Catherine Irwin, i.e. half of Freakwater (#24 and #132).\n\nThe record label is Sophomore Lounge. Ought to be familiar to the Burlington concert crew:\n\nScreenshot 2025-05-08 084632.png\n\nMakes sense. These guys were opening* for Lenderman on the fall '24 tour.\n\nThat's all for now. Seemed worth sharing. Ground floor stuff.\n_____________________________\n\nSong #364: \"Your Still Standin' There\" [sic]\nWho Made it: Steve Earle & Lucinda Williams\nYear: 1996\n_______________________________\n\nThoughts: For a while, I had this slated as the year's last song. It's what I had in mind on #1 when I promised something that would \"mirror [\"RotGA\"] in form and content\" for the finale.\n\nThat much is true: instead of Emmylou and Gram, we have Lucinda and Steve. Instead of 'twenty-thousand roads', it's 'a thousand trails'.\n\nThe arc is much the same:\n\nOh, and I remembered something you once told me\nAnd I'll be damned if it did not come true\nTwenty thousand roads I went down, down, down\nAnd they all lead me straight back home to you (\"RotGA\")\n\nAnd the world keeps turning 'round and 'round\nIt leaves me hanging in the air\nMy heart keeps turning upside down\nAnd you're still standin' there (\"Standin' There\")\n\nMake the sounds of 'down, down, down' v. 'round and round'.\n\n*******************\n\nWhy'd I change my mind? Why isn't this one the closer?\n\nToo final. Too triumphant. Baller Ball told me not to overwrite my endings, and I mean to take his advice.\n\nExpect less next, and more to ponder.\n\n–Matt\n\nPS: Writing this last bit around 10:45 pm. The folks are in town for a visit. I met up with them for dinner, then walked them back to their hotel.\n\nAfter that, all kinds of crap** broke loose. Houston did its best to cut the list short by setting a severe thunderstorm on me during my bike ride home. Flash-bang thunder, blow-down wind, standing water — the works. Don't tell Dan and Julie, but I almost got smacked (inches of separation) by some numb-nut double-dipping the four-way at Woodhead and Welch. I fish-tailed, took the lord's name, then recovered and continued.\n\nI will not be denied: unless the night smites me, we'll have our last song.\n\n*Worth a click for anyone who likes Zevon, cowbell, or fitting loads of people on a stage.\n\n**After I made it home and stripped off my wet stuff, I found a large insectoid invader — not much risk of injury, but significant insult to spirit. I chased it around au naturel, shoe-in-hand, until a blow landed.\n\nPray for a pestless tomorrow.\n\nArchive\nPlaylist",
     "artistWiki": "https://en.wikipedia.org/?curid=194910",
@@ -9540,7 +9540,7 @@
     "relatedArtists": {
       "album": [
         "Steve Earle",
-        "Ken Moore", 
+        "Ken Moore",
         "Richard Bennett",
         "Lucinda Williams",
         "Kris Wilkerson",
@@ -9550,6 +9550,24 @@
       ],
       "other": [
         "Emmylou Harris"
+      ]
+    }
+  },
+  {
+    "number": 365,
+    "song": "Only Him or Me",
+    "artist": "Townes Van Zandt",
+    "album": "Delta Momma Blues",
+    "spotifyLink": "https://open.spotify.com/track/5g0QhEDLGS2yPxZ8z0XCHf",
+    "textBody": "\"Welp\" is in my throat. Hands are striking thighs.\nTime to wrap it up.\n_____________________________\nSong #365: \"Only Him or Me\"\nWho Made it: Townes Van Zandt\nYear: 1971\n_______________________________\nThoughts:\n\nQ: How do you pick the last one?\nA: Punt to someone else.\n\n\"Someone else\" is Van Zandt at the Old Quarter, July '73. As he said then:\n\n\"It's a good song, kinda, to play last. It's about . . . kinda about leavin'.\"\nI'm not leavin', but we're done — wind-blown.*\n******************\nRaise a toast if you find the time:\nSo here's to feelin' good And here's to feelin' bad Here's to bein' thankful And sorry for the pleasures that we had And autumn days and window panes God forgive us if you feel deceived\nFrom today to tomorrow, here's to all that.\nLet it sit when it's over.\n–Matt\n\n*Mostly done. By whim, there might be some follow-ups/supplements down the line — a risk you ran when you came onboard.",
+    "artistWiki": "https://en.wikipedia.org/?curid=292709",
+    "albumWiki": "https://en.wikipedia.org/wiki/Delta_Momma_Blues",
+    "relatedArtists": {
+      "album": [
+        "Townes Van Zandt"
+      ],
+      "other": [
+        "Townes Van Zandt"
       ]
     }
   }

--- a/src/data/processed/download_covers_itunes.js
+++ b/src/data/processed/download_covers_itunes.js
@@ -1,0 +1,157 @@
+// download_covers_itunes.js
+// Downloads album covers from the iTunes Search API (free, no API key needed).
+// Usage: node --experimental-vm-modules src/data/processed/download_covers_itunes.js
+//        (or: node src/data/processed/download_covers_itunes.js if package.json has "type":"module")
+//
+// Options:
+//   --all        Re-download all covers (default: only missing ones)
+//   --dry-run    Print what would be downloaded without saving
+
+import fs from 'fs/promises';
+import path from 'path';
+import axios from 'axios';
+import sharp from 'sharp';
+
+const SONGS_JSON = new URL('../songs_cleaned.json', import.meta.url).pathname;
+const OUTPUT_DIR = new URL('../../../../public/covers', import.meta.url).pathname;
+const ITUNES_API = 'https://itunes.apple.com/search';
+
+const args = process.argv.slice(2);
+const ALL_MODE = args.includes('--all');
+const DRY_RUN = args.includes('--dry-run');
+
+await fs.mkdir(OUTPUT_DIR, { recursive: true });
+
+function safeName(songId, album) {
+  return `${songId}_${album.replace(/[^a-z0-9]/gi, '_')}.png`;
+}
+
+function artworkUrl(url100) {
+  // iTunes returns 100x100 artwork; swap for 600x600
+  return url100.replace('100x100bb', '600x600bb');
+}
+
+async function searchItunes(albumName, artistName) {
+  // Try album + artist first, then just album
+  const queries = [
+    `${albumName} ${artistName}`,
+    albumName,
+  ];
+
+  for (const term of queries) {
+    try {
+      const { data } = await axios.get(ITUNES_API, {
+        params: { term, entity: 'album', media: 'music', limit: 10 },
+        timeout: 10000,
+      });
+
+      if (!data.results?.length) continue;
+
+      // Score results by how closely they match album name and artist
+      const albumLow = albumName.toLowerCase();
+      const artistLow = artistName.toLowerCase().split(/[&,]/)[0].trim(); // primary artist
+
+      const scored = data.results
+        .filter(r => r.artworkUrl100)
+        .map(r => {
+          const rAlbum = (r.collectionName || '').toLowerCase();
+          const rArtist = (r.artistName || '').toLowerCase();
+          let score = 0;
+          if (rAlbum === albumLow) score += 20;
+          else if (rAlbum.includes(albumLow) || albumLow.includes(rAlbum)) score += 10;
+          if (rArtist.includes(artistLow) || artistLow.includes(rArtist)) score += 15;
+          return { score, url: artworkUrl(r.artworkUrl100), album: r.collectionName, artist: r.artistName };
+        })
+        .sort((a, b) => b.score - a.score);
+
+      if (scored.length && scored[0].score > 0) {
+        return scored[0];
+      }
+    } catch (err) {
+      console.log(`  iTunes request failed for "${term}": ${err.message}`);
+    }
+  }
+  return null;
+}
+
+async function downloadCover(url, outPath) {
+  const response = await axios.get(url, {
+    responseType: 'arraybuffer',
+    timeout: 15000,
+    validateStatus: s => s === 200,
+  });
+  if (!response.data || response.data.length < 1000) {
+    throw new Error(`Response too small (${response.data?.length ?? 0} bytes)`);
+  }
+  await sharp(response.data)
+    .resize(500, 500, { fit: 'inside', withoutEnlargement: true })
+    .png()
+    .toFile(outPath);
+  const stat = await fs.stat(outPath);
+  if (stat.size < 1000) throw new Error(`Output file too small (${stat.size} bytes)`);
+  return stat.size;
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+const songs = JSON.parse(await fs.readFile(SONGS_JSON, 'utf8'));
+
+// Build map: normalized album → { number (earliest), album, artist }
+const albumMap = {};
+for (const s of songs) {
+  const norm = s.album?.toLowerCase().trim();
+  if (!norm) continue;
+  if (!albumMap[norm] || s.number < albumMap[norm].number) {
+    albumMap[norm] = { number: s.number, album: s.album, artist: s.artist };
+  }
+}
+
+const albums = Object.values(albumMap).sort((a, b) => a.number - b.number);
+console.log(`Total unique albums: ${albums.length}`);
+
+let downloaded = 0, skipped = 0, failed = 0;
+
+for (const { number, album, artist } of albums) {
+  const filename = safeName(number, album);
+  const outPath = path.join(OUTPUT_DIR, filename);
+
+  // Skip existing unless --all
+  if (!ALL_MODE) {
+    try {
+      await fs.access(outPath);
+      skipped++;
+      continue;
+    } catch {
+      // file doesn't exist → proceed
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log(`[DRY] Would fetch: "${album}" by "${artist}" → ${filename}`);
+    continue;
+  }
+
+  process.stdout.write(`[${number}] "${album}" (${artist}) … `);
+
+  const result = await searchItunes(album, artist);
+  if (!result) {
+    console.log('✗ not found on iTunes');
+    failed++;
+    continue;
+  }
+
+  try {
+    const size = await downloadCover(result.url, outPath);
+    console.log(`✓ ${result.album} / ${result.artist} (${size} bytes)`);
+    downloaded++;
+  } catch (err) {
+    console.log(`✗ download failed: ${err.message}`);
+    failed++;
+    // clean up partial file
+    await fs.unlink(outPath).catch(() => {});
+  }
+
+  // Be polite to iTunes API – small delay between requests
+  await new Promise(r => setTimeout(r, 300));
+}
+
+console.log(`\nDone. Downloaded: ${downloaded}, Skipped (existing): ${skipped}, Failed: ${failed}`);

--- a/src/data/songs_cleaned.json
+++ b/src/data/songs_cleaned.json
@@ -10490,5 +10490,25 @@
     "genres": [],
     "wordCount": 357,
     "is_tragic": 0
+  },
+  {
+    "number": 365,
+    "song": "Only Him or Me",
+    "artist": "Townes Van Zandt",
+    "album": "Delta Momma Blues",
+    "spotifyLink": "https://open.spotify.com/track/5g0QhEDLGS2yPxZ8z0XCHf",
+    "artistWiki": "https://en.wikipedia.org/?curid=292709",
+    "albumWiki": "https://en.wikipedia.org/wiki/Delta_Momma_Blues",
+    "relatedArtists": {
+      "album": [
+        "Townes Van Zandt"
+      ],
+      "other": [
+        "Townes Van Zandt"
+      ]
+    },
+    "genres": [],
+    "wordCount": 163,
+    "is_tragic": 1
   }
 ]


### PR DESCRIPTION
## Summary
This PR adds an automated album cover downloader using the iTunes Search API and completes the song list with entry #365, the final song in the collection.

## Key Changes

- **New script: `download_covers_itunes.js`**
  - Downloads album covers from iTunes Search API (free, no authentication required)
  - Intelligently scores and matches results by album name and artist
  - Resizes images to 500x500px using Sharp for consistent sizing
  - Supports `--all` flag to re-download existing covers and `--dry-run` for preview mode
  - Includes polite rate limiting (300ms between requests) and comprehensive error handling
  - Validates downloaded files to ensure minimum quality (1KB threshold)

- **Added final song entry (#365)**
  - Song: "Only Him or Me" by Townes Van Zandt from *Delta Momma Blues* (1971)
  - Includes full metadata, Spotify link, and related artists
  - Marked as tragic (`is_tragic: 1`)
  - Completes the song collection with a thematic closing note about endings

- **Minor formatting fixes**
  - Removed trailing whitespace in `entries.json` (song #364)

## Implementation Details

The iTunes downloader:
- Uses normalized album names to deduplicate and group songs by album
- Implements a two-tier search strategy (album + artist, then album only)
- Scores matches based on exact/partial name matches and artist alignment
- Handles primary artist extraction from multi-artist credits
- Gracefully degrades with detailed logging for debugging
- Cleans up partial/failed downloads automatically

https://claude.ai/code/session_01DYCBC2tSnQqcVVjgvHwVSa